### PR TITLE
Fix-E2E-tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
     },
     {
       name: 'mobile',
-      use: { ...devices['iPhone 13'] },
+      use: {
+        ...devices['iPhone 13'],
+        // Use Chromium instead of WebKit — CI only installs Chromium
+        browserName: 'chromium',
+      },
       testMatch: '**/mobile.e2e.spec.ts',
     },
   ],

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -80,11 +80,15 @@ export default buildConfig({
   },
   // This config helps us configure global or default features that the other editors can inherit
   editor: defaultLexical,
-  email: resendAdapter({
-    defaultFromAddress: process.env.RESEND_FROM_ADDRESS || 'info@limitless-longevity.health',
-    defaultFromName: 'PATHS by LIMITLESS',
-    apiKey: process.env.RESEND_API_KEY || '',
-  }),
+  ...(process.env.CI !== 'true'
+    ? {
+        email: resendAdapter({
+          defaultFromAddress: process.env.RESEND_FROM_ADDRESS || 'info@limitless-longevity.health',
+          defaultFromName: 'PATHS by LIMITLESS',
+          apiKey: process.env.RESEND_API_KEY || '',
+        }),
+      }
+    : {}),
   db: postgresAdapter({
     pool: {
       connectionString: process.env.DATABASE_URL,


### PR DESCRIPTION
- Use Chromium browser for mobile E2E tests instead of WebKit
  (CI only installs Chromium via npx playwright install chromium)
- Skip Resend email adapter in CI to prevent 401 API key errors
  during E2E test flows that trigger email sending

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
