### PR TITLE
Fix-E2E-timeout

### DIFF
--- a/scripts/ci-migrate.ts
+++ b/scripts/ci-migrate.ts
@@ -1,21 +1,35 @@
 /**
  * CI Migration Script
  *
- * Initializes Payload with prodMigrations to create all database tables.
+ * Initializes the database schema by temporarily enabling Drizzle push.
  * Used in CI before running integration and E2E tests.
+ *
+ * The main payload.config.ts has push: false (production safety).
+ * This script overrides that for the one-time CI schema setup.
  */
 
-import config from '../src/payload.config.js'
 import { getPayload } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import configPromise from '../src/payload.config.js'
 
 async function main() {
-  console.log('Running database migrations via getPayload()...')
+  console.log('Initializing database schema (push: true)...')
+
+  const config = await configPromise
+
+  // Override the db adapter to enable push for schema creation
+  const originalDb = config.db
+  config.db = postgresAdapter({
+    pool: { connectionString: process.env.DATABASE_URL! },
+    push: true,
+  })
+
   await getPayload({ config })
-  console.log('Migrations applied successfully.')
+  console.log('Database schema initialized successfully.')
   process.exit(0)
 }
 
 main().catch((err) => {
-  console.error('Migration failed:', err)
+  console.error('Schema initialization failed:', err)
   process.exit(1)
 })

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -93,7 +93,7 @@ export default buildConfig({
     pool: {
       connectionString: process.env.DATABASE_URL,
     },
-    push: process.env.CI === 'true',
+    push: false,
     prodMigrations: migrations,
   }),
   collections: [Pages, Posts, Media, Categories, Users, MembershipTiers, ContentPillars, Tenants, Articles, Courses, Modules, Lessons, Enrollments, LessonProgress, AIUsage, ContentChunks, Subscriptions, StripeEvents],


### PR DESCRIPTION
push:true in config caused Drizzle to re-push schema on every
getPayload() call during E2E tests (37 min runtime). Now push:false
in config, and ci-migrate.ts overrides the db adapter to push once
during the dedicated setup step.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
