### PR TITLE
Add safe diagnostics to staging DB connection test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,12 @@ jobs:
         run: |
           npx tsx -e "
             import pg from 'pg';
+            const url = new URL(process.env.DATABASE_URL!);
+            const isExternal = url.hostname.includes('-postgres.render.com');
+            console.log('External hostname:', isExternal ? 'yes' : 'NO — likely using internal hostname');
+            console.log('Has port:', url.port ? 'yes (' + url.port + ')' : 'default (5432)');
+            console.log('Has database:', url.pathname.length > 1 ? 'yes' : 'no');
+            console.log('Has credentials:', url.username ? 'yes' : 'no');
             const c = new pg.Client({
               connectionString: process.env.DATABASE_URL,
               ssl: { rejectUnauthorized: false }


### PR DESCRIPTION
## Summary
- Add non-secret diagnostics to the staging DB connection test step
- Checks whether the URL uses external hostname pattern, has credentials, port, and database
- Does NOT log actual hostnames, usernames, or passwords (repo is public)
- Connection test still fails with "Connection terminated unexpectedly" — this will help identify if the secret has the wrong hostname format

## Context
The raw pg connection test confirmed the issue is at the TCP/SSL level, not in Payload. The most likely cause is the `STAGING_DATABASE_URL` secret using an internal hostname instead of external.

## Test plan
- [ ] Merge, trigger on main, check diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)