### PR TITLE
Fix E2E seed helpers: deterministic slugs (#20)

### DIFF
--- a/tests/helpers/seedContent.ts
+++ b/tests/helpers/seedContent.ts
@@ -92,13 +92,11 @@ export async function seedArticle(data: {
   content?: any
 }): Promise<any> {
   const payload = await getPayload({ config })
-  const suffix = Date.now().toString(36)
-  const uniqueSlug = `${data.slug}-${suffix}`
 
-  // Delete existing (match both original and suffixed slugs)
+  // Delete existing articles matching this slug
   await payload.delete({
     collection: 'articles',
-    where: { slug: { contains: data.slug } },
+    where: { slug: { equals: data.slug } },
     overrideAccess: true,
   }).catch(() => {})
 
@@ -106,7 +104,8 @@ export async function seedArticle(data: {
     collection: 'articles',
     data: {
       title: data.title,
-      slug: uniqueSlug,
+      slug: data.slug,
+      generateSlug: false,
       excerpt: data.excerpt,
       accessLevel: data.accessLevel,
       editorialStatus: data.editorialStatus ?? 'draft',
@@ -131,13 +130,18 @@ export async function seedCourse(data: {
   instructorId: number
 }): Promise<{ courseId: number; moduleId: number; lessonIds: number[] }> {
   const payload = await getPayload({ config })
-  const suffix = Date.now().toString(36)
-  const uniqueSlug = `${data.slug}-${suffix}`
 
-  // Delete existing (match both original and suffixed slugs)
+  // Delete existing course matching this slug
   await payload.delete({
     collection: 'courses',
-    where: { slug: { contains: data.slug } },
+    where: { slug: { equals: data.slug } },
+    overrideAccess: true,
+  }).catch(() => {})
+
+  // Clean up lessons from previous runs
+  await payload.delete({
+    collection: 'lessons',
+    where: { slug: { contains: `${data.slug}-lesson` } },
     overrideAccess: true,
   }).catch(() => {})
 
@@ -145,7 +149,7 @@ export async function seedCourse(data: {
     collection: 'courses',
     data: {
       title: data.title,
-      slug: uniqueSlug,
+      slug: data.slug,
       accessLevel: data.accessLevel,
       editorialStatus: 'published',
       tenant: data.tenantId,
@@ -170,7 +174,7 @@ export async function seedCourse(data: {
     collection: 'lessons',
     data: {
       title: 'Lesson 1: Introduction',
-      slug: `test-lesson-1-intro-${suffix}`,
+      slug: `${data.slug}-lesson-1-intro`,
       module: testModule.id,
       order: 1,
       lessonType: 'text',
@@ -193,7 +197,7 @@ export async function seedCourse(data: {
     collection: 'lessons',
     data: {
       title: 'Lesson 2: Deep Dive',
-      slug: `test-lesson-2-deep-dive-${suffix}`,
+      slug: `${data.slug}-lesson-2-deep-dive`,
       module: testModule.id,
       order: 2,
       lessonType: 'text',


### PR DESCRIPTION
## Summary
- Remove random `Date.now()` suffix from article/course slugs — they now match fixture values E2E tests use for navigation
- Add `generateSlug: false` to prevent Payload's `slugField()` hook from overwriting explicit slugs
- Use exact match for cleanup queries
- Make lesson slugs deterministic based on course slug

Closes #20

## Test plan
- [ ] CI Test & Build passes
- [ ] E2E tests improve (may still have other pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)