### PR TITLE
Add basePath /learn for API gateway routing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,7 @@ const nextConfig: NextConfig = {
     return webpackConfig
   },
   reactStrictMode: true,
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   redirects,
   turbopack: {
     root: path.resolve(dirname),


### PR DESCRIPTION
## Summary
Configure Next.js `basePath` from `NEXT_PUBLIC_BASE_PATH` env var for Cloudflare Worker gateway routing.

Set to `/learn` on Render — all PATHS routes serve under `/learn/*` when accessed via `app.limitless-longevity.health`. Local dev and direct Render URLs use empty basePath.

Next.js auto-prefixes `<Link>`, `router.push`, `redirect`, API routes, and static assets. No hardcoded path changes needed.

## Env vars to set on Render (after merge)
- `NEXT_PUBLIC_BASE_PATH=/learn`
- `NEXT_PUBLIC_SERVER_URL=https://app.limitless-longevity.health/learn` (or keep direct Render URL)

## Test plan
- [ ] `NEXT_PUBLIC_BASE_PATH=/learn pnpm build` passes
- [ ] CI Test & Build passes
- [ ] All pages render under `/learn/*` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)