### PR TITLE
Add internal tier-sync endpoint for HUB integration

### DIFF
--- a/src/endpoints/internal/tier-sync.ts
+++ b/src/endpoints/internal/tier-sync.ts
@@ -1,0 +1,79 @@
+import type { Endpoint } from 'payload'
+
+/**
+ * Internal tier-sync endpoint — called by HUB when membership changes.
+ * Updates user's membership tier in PATHS to match their HUB subscription.
+ *
+ * Auth: API key in X-Service-Key header (not user JWT).
+ *
+ * Body: { userId: string, tier: 'free' | 'regular' | 'premium' | 'enterprise' }
+ */
+
+const TIER_MAP: Record<string, string> = {
+  free: 'free',
+  regular: 'regular',
+  premium: 'premium',
+  enterprise: 'enterprise',
+}
+
+export const tierSyncEndpoint: Endpoint = {
+  path: '/internal/tier-sync',
+  method: 'post',
+  handler: async (req) => {
+    // Verify service key
+    const serviceKey = req.headers.get('x-service-key')
+    if (!serviceKey || serviceKey !== process.env.HUB_SERVICE_KEY) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Parse body
+    let body: { userId: string; tier: string }
+    try {
+      body = await req.json!()
+    } catch {
+      return Response.json({ error: 'Invalid JSON' }, { status: 400 })
+    }
+
+    const { userId, tier } = body
+    if (!userId || !tier) {
+      return Response.json({ error: 'Missing userId or tier' }, { status: 400 })
+    }
+
+    if (!TIER_MAP[tier]) {
+      return Response.json({ error: `Invalid tier: ${tier}` }, { status: 400 })
+    }
+
+    // Find user by ID
+    const users = await req.payload.find({
+      collection: 'users',
+      where: { id: { equals: userId } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    if (users.docs.length === 0) {
+      return Response.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    // Find user's membership tier and update
+    const tiers = await req.payload.find({
+      collection: 'membership-tiers',
+      where: { slug: { equals: TIER_MAP[tier] } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    if (tiers.docs.length === 0) {
+      return Response.json({ error: `Tier not found: ${tier}` }, { status: 404 })
+    }
+
+    await req.payload.update({
+      collection: 'users',
+      id: users.docs[0].id,
+      data: { tier: tiers.docs[0].id },
+      overrideAccess: true,
+    })
+
+    return Response.json({ success: true, userId, tier: TIER_MAP[tier] })
+  },
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -54,6 +54,7 @@ import { dailyProtocolEndpoint } from './endpoints/ai/dailyProtocol'
 import { dailyProtocolStatusEndpoint } from './endpoints/ai/dailyProtocolStatus'
 import { resendVerificationEndpoint } from './endpoints/auth/resend-verification'
 import { healthEndpoint } from './endpoints/health'
+import { tierSyncEndpoint } from './endpoints/internal/tier-sync'
 import { migrations } from './migrations'
 import { getServerSideURL } from './utilities/getURL'
 import { validateEnv } from './utilities/validateEnv'
@@ -112,7 +113,7 @@ export default buildConfig({
   }),
   collections: [Pages, Posts, Media, Categories, Users, MembershipTiers, ContentPillars, Tenants, Articles, Courses, Modules, Lessons, Enrollments, LessonProgress, AIUsage, ContentChunks, Subscriptions, StripeEvents, HealthProfiles, ActionPlans, DailyProtocols, Certificates],
   cors: [getServerSideURL()].filter(Boolean),
-  endpoints: [healthEndpoint, tutorEndpoint, quizGenerateEndpoint, quizSaveEndpoint, semanticSearchEndpoint, recommendationsEndpoint, relatedContentEndpoint, enrollEndpoint, stripeWebhookEndpoint, billingCheckoutEndpoint, billingPortalEndpoint, registerEndpoint, contactSalesEndpoint, diagnosticBookingEndpoint, stayBookingEndpoint, telemedicineBookingEndpoint, discoverEndpoint, actionPlanEndpoint, dailyProtocolEndpoint, dailyProtocolStatusEndpoint, resendVerificationEndpoint],
+  endpoints: [healthEndpoint, tutorEndpoint, quizGenerateEndpoint, quizSaveEndpoint, semanticSearchEndpoint, recommendationsEndpoint, relatedContentEndpoint, enrollEndpoint, stripeWebhookEndpoint, billingCheckoutEndpoint, billingPortalEndpoint, registerEndpoint, contactSalesEndpoint, diagnosticBookingEndpoint, stayBookingEndpoint, telemedicineBookingEndpoint, discoverEndpoint, actionPlanEndpoint, dailyProtocolEndpoint, dailyProtocolStatusEndpoint, resendVerificationEndpoint, tierSyncEndpoint],
   globals: [Header, Footer, SiteSettings, AIConfig],
   plugins,
   secret: process.env.PAYLOAD_SECRET,


### PR DESCRIPTION
## Summary
New internal endpoint `POST /api/internal/tier-sync` for HUB membership integration.

When HUB membership changes (subscribe, upgrade, cancel), HUB calls this endpoint to sync the user's PATHS tier. Auth via `X-Service-Key` header.

**Tier mapping:**
- Optimus/Immortalitas/Transcendentia/VIP → premium
- E-Clinic → regular
- Cancel → free

## Test plan
- [ ] `pnpm build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)