### PR TITLE
Add cross-service links: HUB nav, AI tutor CTA, login redirect

### DIFF
--- a/public/guide/search-index.json
+++ b/public/guide/search-index.json
@@ -458,8 +458,8 @@
     "role": "publisher",
     "topic": "content-analytics",
     "title": "content-analytics",
-    "description": "",
-    "body": "---\r\ntitle: Content Analytics\r\ndescription: Tracking content performance and engagement metrics on the PATHS platform. This feature is coming soon.\r\n---\r\n\r\nContent Analytics\r\n\r\n\r\n\r\n\r\nContent analytics is a planned feature that is not yet available on the PATHS platform. This guide describes the capa",
+    "description": "Tracking content performance and engagement metrics on the PATHS platform. This feature is coming soon.",
+    "body": "Content Analytics\nContent analytics is a planned feature that is not yet available on the PATHS platform. This guide describes the capabilities that are being developed. You will be notified when analytics features become available.\nPlanned Analytics Features\nThe analytics system will give Publisher",
     "headings": [
       "Content Analytics",
       "Planned Analytics Features",

--- a/src/Header/Nav/index.tsx
+++ b/src/Header/Nav/index.tsx
@@ -17,6 +17,11 @@ const CONTENT_NAV = [
   { href: '/guide', label: 'Guide' },
 ]
 
+/** External links served by the gateway Worker (not Next.js routes) */
+const EXTERNAL_NAV = [
+  { href: '/book', label: 'Book' },
+]
+
 export const HeaderNav: React.FC<{ data: HeaderType; mobile?: boolean }> = ({ data, mobile }) => {
   const navItems = data?.navItems || []
   const pathname = usePathname()
@@ -40,6 +45,15 @@ export const HeaderNav: React.FC<{ data: HeaderType; mobile?: boolean }> = ({ da
         >
           {item.label}
         </Link>
+      ))}
+      {EXTERNAL_NAV.map((item) => (
+        <a
+          key={item.href}
+          href={item.href}
+          className={linkClasses(false)}
+        >
+          {item.label}
+        </a>
       ))}
       {navItems.map(({ link }, i) => {
         return (

--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -1,12 +1,30 @@
 'use client'
 import React, { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/utilities/ui'
 import Link from 'next/link'
 import { useAuth } from '@/providers/Auth'
 
+/**
+ * Validate that a redirect URL is safe (same-origin).
+ * Allows paths starting with `/` but rejects protocol-relative URLs and absolute URLs to other hosts.
+ */
+function isValidRedirect(url: string): boolean {
+  if (!url) return false
+  // Must start with `/` and must NOT start with `//` (protocol-relative)
+  if (!url.startsWith('/') || url.startsWith('//')) return false
+  try {
+    // Parse against a dummy base — if the resulting origin differs, it's not same-origin
+    const parsed = new URL(url, window.location.origin)
+    return parsed.origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
 export default function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const auth = useAuth()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -29,7 +47,9 @@ export default function LoginForm() {
       if (res.ok) {
         if (data.user) auth.setUser(data.user)
         setMessage({ type: 'success', text: 'Signed in! Redirecting...' })
-        setTimeout(() => router.push('/courses'), 1000)
+        const redirectTo = searchParams.get('redirect')
+        const destination = redirectTo && isValidRedirect(redirectTo) ? redirectTo : '/courses'
+        setTimeout(() => router.push(destination), 1000)
       } else {
         setMessage({ type: 'error', text: data.errors?.[0]?.message || 'Invalid email or password.' })
       }

--- a/src/app/(frontend)/login/page.tsx
+++ b/src/app/(frontend)/login/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import LoginForm from './LoginForm'
 
 export const dynamic = 'force-dynamic'
@@ -9,5 +10,9 @@ export const metadata: Metadata = {
 }
 
 export default function LoginPage() {
-  return <LoginForm />
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  )
 }

--- a/src/components/TutorPanel/index.tsx
+++ b/src/components/TutorPanel/index.tsx
@@ -283,12 +283,12 @@ export const TutorPanel: React.FC<{
                   <p className="text-xs text-brand-silver mb-3">
                     This topic may benefit from personalized guidance from our medical team.
                   </p>
-                  <button
-                    onClick={() => setShowBookingForm(true)}
-                    className="text-xs font-medium text-brand-gold hover:text-brand-gold/80 transition-colors"
+                  <a
+                    href="/book/telemedicine"
+                    className="inline-block px-4 py-2 rounded-full text-xs font-medium uppercase tracking-[0.1em] border border-brand-gold bg-brand-gold text-brand-dark hover:bg-brand-gold/90 transition-all min-h-[44px] leading-[28px] text-center"
                   >
-                    Book a Telemedicine Consultation →
-                  </button>
+                    Book a Telemedicine Consultation
+                  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Cross-service integration for the Longevity OS gateway.

- **Header:** "Book" link → `/book` (HUB via Cloudflare Worker gateway)
- **AI tutor:** `[SUGGEST_CONSULTATION]` renders CTA linking to `/book/telemedicine`
- **Login redirect:** `?redirect=` parameter with same-origin validation — enables HUB → PATHS login → HUB dashboard flow

## Test plan
- [ ] `pnpm build` passes
- [ ] Header shows "Book" link
- [ ] Login with `?redirect=/book/dashboard` redirects correctly after auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)