### PR TITLE
Fix Render deploy: add root redirect for basePath

### DIFF
--- a/redirects.ts
+++ b/redirects.ts
@@ -14,5 +14,18 @@ export const redirects: NextConfig['redirects'] = async () => {
     source: '/:path((?!ie-incompatible.html$).*)', // all pages except the incompatibility page
   }
 
-  return [internetExplorerRedirect]
+  const redirectsList = [internetExplorerRedirect]
+
+  // When basePath is set, redirect root to basePath so Render health checks
+  // and direct URL visitors get a valid response instead of 404
+  if (process.env.NEXT_PUBLIC_BASE_PATH) {
+    redirectsList.push({
+      source: '/',
+      destination: process.env.NEXT_PUBLIC_BASE_PATH,
+      permanent: false,
+      basePath: false as any,
+    })
+  }
+
+  return redirectsList
 }


### PR DESCRIPTION
## URGENT
Render deploys fail because health check hits `/` which 404s with basePath set.

Adds root redirect: `/` → `/learn` when `NEXT_PUBLIC_BASE_PATH` is set. Combined with Terraform health check path update (`/learn/api/health`), this fixes the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)