### PR TITLE
Add dashboard API: enrollments + protocol endpoints

### DIFF
--- a/src/endpoints/me/enrollments.ts
+++ b/src/endpoints/me/enrollments.ts
@@ -1,0 +1,51 @@
+import type { Endpoint } from 'payload'
+
+/**
+ * GET /api/me/enrollments
+ * Returns authenticated user's course enrollments with progress.
+ * Used by the OS Dashboard learning progress widget.
+ */
+export const myEnrollmentsEndpoint: Endpoint = {
+  path: '/me/enrollments',
+  method: 'get',
+  handler: async (req) => {
+    if (!req.user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const enrollments = await req.payload.find({
+      collection: 'enrollments',
+      where: { user: { equals: req.user.id } },
+      depth: 1,
+      limit: 50,
+      sort: '-enrolledAt',
+      overrideAccess: false,
+      user: req.user,
+      req,
+    })
+
+    const mapped = enrollments.docs.map((enrollment: any) => ({
+      id: enrollment.id,
+      course: enrollment.course
+        ? {
+            id: enrollment.course.id || enrollment.course,
+            title: enrollment.course.title || '',
+            slug: enrollment.course.slug || '',
+          }
+        : null,
+      progress: enrollment.completionPercentage || 0,
+      status: enrollment.status,
+      enrolledAt: enrollment.enrolledAt,
+      completedAt: enrollment.completedAt || null,
+    }))
+
+    const totalActive = mapped.filter((e: any) => e.status === 'active').length
+    const totalCompleted = mapped.filter((e: any) => e.status === 'completed').length
+
+    return Response.json({
+      enrollments: mapped,
+      totalActive,
+      totalCompleted,
+    })
+  },
+}

--- a/src/endpoints/me/protocol.ts
+++ b/src/endpoints/me/protocol.ts
@@ -1,0 +1,53 @@
+import type { Endpoint } from 'payload'
+
+/**
+ * GET /api/me/protocol
+ * Returns today's daily protocol for the authenticated user.
+ * Used by the OS Dashboard daily protocol widget.
+ */
+export const myProtocolEndpoint: Endpoint = {
+  path: '/me/protocol',
+  method: 'get',
+  handler: async (req) => {
+    if (!req.user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const today = new Date().toISOString().split('T')[0]
+
+    const protocols = await req.payload.find({
+      collection: 'daily-protocols',
+      where: {
+        and: [
+          { user: { equals: req.user.id } },
+          { date: { equals: today } },
+          { status: { equals: 'ready' } },
+        ],
+      },
+      limit: 1,
+      sort: '-date',
+      overrideAccess: false,
+      user: req.user,
+      req,
+    })
+
+    if (protocols.docs.length === 0) {
+      return Response.json({ date: today, protocol: null })
+    }
+
+    const doc = protocols.docs[0] as any
+    const totalCount = doc.totalCount || 0
+    const completedCount = doc.completedCount || 0
+
+    return Response.json({
+      date: today,
+      protocol: {
+        id: doc.id,
+        items: doc.protocol || [],
+        completionRate: totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0,
+        completedCount,
+        totalCount,
+      },
+    })
+  },
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -55,6 +55,8 @@ import { dailyProtocolStatusEndpoint } from './endpoints/ai/dailyProtocolStatus'
 import { resendVerificationEndpoint } from './endpoints/auth/resend-verification'
 import { healthEndpoint } from './endpoints/health'
 import { tierSyncEndpoint } from './endpoints/internal/tier-sync'
+import { myEnrollmentsEndpoint } from './endpoints/me/enrollments'
+import { myProtocolEndpoint } from './endpoints/me/protocol'
 import { migrations } from './migrations'
 import { getServerSideURL } from './utilities/getURL'
 import { validateEnv } from './utilities/validateEnv'
@@ -113,7 +115,7 @@ export default buildConfig({
   }),
   collections: [Pages, Posts, Media, Categories, Users, MembershipTiers, ContentPillars, Tenants, Articles, Courses, Modules, Lessons, Enrollments, LessonProgress, AIUsage, ContentChunks, Subscriptions, StripeEvents, HealthProfiles, ActionPlans, DailyProtocols, Certificates],
   cors: [getServerSideURL()].filter(Boolean),
-  endpoints: [healthEndpoint, tutorEndpoint, quizGenerateEndpoint, quizSaveEndpoint, semanticSearchEndpoint, recommendationsEndpoint, relatedContentEndpoint, enrollEndpoint, stripeWebhookEndpoint, billingCheckoutEndpoint, billingPortalEndpoint, registerEndpoint, contactSalesEndpoint, diagnosticBookingEndpoint, stayBookingEndpoint, telemedicineBookingEndpoint, discoverEndpoint, actionPlanEndpoint, dailyProtocolEndpoint, dailyProtocolStatusEndpoint, resendVerificationEndpoint, tierSyncEndpoint],
+  endpoints: [healthEndpoint, tutorEndpoint, quizGenerateEndpoint, quizSaveEndpoint, semanticSearchEndpoint, recommendationsEndpoint, relatedContentEndpoint, enrollEndpoint, stripeWebhookEndpoint, billingCheckoutEndpoint, billingPortalEndpoint, registerEndpoint, contactSalesEndpoint, diagnosticBookingEndpoint, stayBookingEndpoint, telemedicineBookingEndpoint, discoverEndpoint, actionPlanEndpoint, dailyProtocolEndpoint, dailyProtocolStatusEndpoint, resendVerificationEndpoint, tierSyncEndpoint, myEnrollmentsEndpoint, myProtocolEndpoint],
   globals: [Header, Footer, SiteSettings, AIConfig],
   plugins,
   secret: process.env.PAYLOAD_SECRET,


### PR DESCRIPTION
## Summary
Two new endpoints for the OS Dashboard widgets:
- `GET /api/me/enrollments` — user's course enrollments with progress percentage
- `GET /api/me/protocol` — today's daily protocol with completion rate

Both require authentication (401 without JWT).

## Test plan
- [ ] `pnpm build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)