### PR TITLE
Fix client-side API calls to include basePath prefix

### DIFF
--- a/src/app/(frontend)/account/profile/page.tsx
+++ b/src/app/(frontend)/account/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useState } from 'react'
 import { cn } from '@/utilities/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 import { SkeletonProfileForm } from '@/components/Skeleton'
 
 export default function ProfilePage() {
@@ -22,7 +23,7 @@ export default function ProfilePage() {
   const [savingPassword, setSavingPassword] = useState(false)
 
   useEffect(() => {
-    fetch('/api/users/me')
+    fetch(apiUrl('/api/users/me'))
       .then((res) => res.json())
       .then((data) => {
         const u = data.user
@@ -40,7 +41,7 @@ export default function ProfilePage() {
     setMessage(null)
 
     try {
-      const res = await fetch(`/api/users/${user.id}`, {
+      const res = await fetch(apiUrl(`/api/users/${user.id}`), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ firstName, lastName }),
@@ -72,7 +73,7 @@ export default function ProfilePage() {
 
     setSavingPassword(true)
     try {
-      const res = await fetch(`/api/users/${user.id}`, {
+      const res = await fetch(apiUrl(`/api/users/${user.id}`), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password: newPassword }),
@@ -144,11 +145,11 @@ export default function ProfilePage() {
                   const formData = new FormData()
                   formData.append('file', file)
                   formData.append('alt', `${firstName} ${lastName} avatar`)
-                  const uploadRes = await fetch('/api/media', { method: 'POST', body: formData })
+                  const uploadRes = await fetch(apiUrl('/api/media'), { method: 'POST', body: formData })
                   if (!uploadRes.ok) throw new Error('Upload failed')
                   const media = await uploadRes.json()
                   // Link to user
-                  await fetch(`/api/users/${user.id}`, {
+                  await fetch(apiUrl(`/api/users/${user.id}`), {
                     method: 'PATCH',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ avatar: media.doc.id }),

--- a/src/app/(frontend)/discover/DiscoverClient.tsx
+++ b/src/app/(frontend)/discover/DiscoverClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { GlassCard } from '@/components/homepage/GlassCard'
 import { TierBadge } from '@/components/TierBadge'
 import { Sparkles, ArrowRight } from 'lucide-react'
+import { apiUrl } from '@/utilities/apiUrl'
 
 const SUGGESTED_PROMPTS = [
   'Optimize my sleep quality',
@@ -40,7 +41,7 @@ export default function DiscoverClient({ isAuthenticated }: { isAuthenticated: b
     setPath(null)
 
     try {
-      const res = await fetch('/api/ai/discover', {
+      const res = await fetch(apiUrl('/api/ai/discover'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query: searchQuery, limit: 6 }),

--- a/src/app/(frontend)/forgot-password/ForgotPasswordForm.tsx
+++ b/src/app/(frontend)/forgot-password/ForgotPasswordForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState } from 'react'
 import { cn } from '@/utilities/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 import Link from 'next/link'
 
 export default function ForgotPasswordForm() {
@@ -14,7 +15,7 @@ export default function ForgotPasswordForm() {
     setSubmitting(true)
 
     try {
-      const res = await fetch('/api/users/forgot-password', {
+      const res = await fetch(apiUrl('/api/users/forgot-password'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),

--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/utilities/ui'
 import Link from 'next/link'
 import { useAuth } from '@/providers/Auth'
+import { apiUrl } from '@/utilities/apiUrl'
 
 /**
  * Validate that a redirect URL is safe (same-origin).
@@ -37,7 +38,7 @@ export default function LoginForm() {
     setSubmitting(true)
 
     try {
-      const res = await fetch('/api/users/login', {
+      const res = await fetch(apiUrl('/api/users/login'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),

--- a/src/app/(frontend)/register/RegisterForm.tsx
+++ b/src/app/(frontend)/register/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { cn } from '@/utilities/ui'
 import Link from 'next/link'
 import { useAuth } from '@/providers/Auth'
+import { apiUrl } from '@/utilities/apiUrl'
 
 export default function RegisterForm() {
   const router = useRouter()
@@ -31,7 +32,7 @@ export default function RegisterForm() {
 
     setSubmitting(true)
     try {
-      const res = await fetch('/api/auth/register', {
+      const res = await fetch(apiUrl('/api/auth/register'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password, firstName, lastName }),

--- a/src/app/(frontend)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(frontend)/reset-password/ResetPasswordForm.tsx
@@ -2,6 +2,7 @@
 import React, { useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/utilities/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 import Link from 'next/link'
 
 function ResetPasswordFormInner() {
@@ -31,7 +32,7 @@ function ResetPasswordFormInner() {
     setSubmitting(true)
 
     try {
-      const res = await fetch('/api/users/reset-password', {
+      const res = await fetch(apiUrl('/api/users/reset-password'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, password }),

--- a/src/app/(frontend)/search/page.client.tsx
+++ b/src/app/(frontend)/search/page.client.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label'
 import { ContentListItem, type ContentListItemData } from '@/components/ContentListItem'
 import { useSearchParams } from 'next/navigation'
 import { Sparkles } from 'lucide-react'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type SearchResult = {
   title: string
@@ -45,7 +46,7 @@ const PageClient: React.FC = () => {
     setSearched(true)
 
     try {
-      const res = await fetch('/api/ai/search', {
+      const res = await fetch(apiUrl('/api/ai/search'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query: q.trim(), limit: 12 }),

--- a/src/app/(frontend)/verify-email/VerifyEmailForm.tsx
+++ b/src/app/(frontend)/verify-email/VerifyEmailForm.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/utilities/ui'
 import Link from 'next/link'
 import { useAuth } from '@/providers/Auth'
+import { apiUrl } from '@/utilities/apiUrl'
 
 function VerifyEmailFormInner() {
   const router = useRouter()
@@ -23,14 +24,14 @@ function VerifyEmailFormInner() {
     setMessage(null)
 
     try {
-      const res = await fetch(`/api/users/verify/${token}`, {
+      const res = await fetch(apiUrl(`/api/users/verify/${token}`), {
         method: 'POST',
         credentials: 'include',
       })
 
       if (res.ok) {
         // Refresh auth state
-        const meRes = await fetch('/api/users/me', { credentials: 'include' })
+        const meRes = await fetch(apiUrl('/api/users/me'), { credentials: 'include' })
         if (meRes.ok) {
           const meData = await meRes.json()
           if (meData.user) auth.setUser(meData.user)
@@ -55,7 +56,7 @@ function VerifyEmailFormInner() {
     setResending(true)
     setMessage(null)
     try {
-      const res = await fetch('/api/auth/resend-verification', {
+      const res = await fetch(apiUrl('/api/auth/resend-verification'), {
         method: 'POST',
         credentials: 'include',
       })

--- a/src/components/ActionPlanCTA/index.tsx
+++ b/src/components/ActionPlanCTA/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react'
 import { cn } from '@/utilities/ui'
 import { Sparkles, ChevronDown, ChevronRight, CheckCircle2 } from 'lucide-react'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type WeekDay = {
   dayNumber: number
@@ -64,7 +65,7 @@ export const ActionPlanCTA: React.FC<{
     setError(null)
 
     try {
-      const res = await fetch('/api/ai/action-plan', {
+      const res = await fetch(apiUrl('/api/ai/action-plan'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enrollmentId }),

--- a/src/components/DailyProtocolWidget/index.tsx
+++ b/src/components/DailyProtocolWidget/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react'
 import { cn } from '@/utilities/ui'
 import { GlassCard } from '@/components/homepage/GlassCard'
 import { Sun, CloudSun, Moon, RefreshCw, CheckCircle2, Circle } from 'lucide-react'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type Action = {
   id: string
@@ -43,7 +44,7 @@ export const DailyProtocolWidget: React.FC<{ tierAccess: string }> = ({ tierAcce
 
   const fetchProtocol = async (regenerate = false) => {
     try {
-      const res = await fetch('/api/ai/daily-protocol', {
+      const res = await fetch(apiUrl('/api/ai/daily-protocol'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(regenerate ? { regenerate: true } : {}),
@@ -95,7 +96,7 @@ export const DailyProtocolWidget: React.FC<{ tierAccess: string }> = ({ tierAcce
     })
 
     try {
-      await fetch('/api/ai/daily-protocol-status', {
+      await fetch(apiUrl('/api/ai/daily-protocol-status'), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ protocolId: protocol.id, actionId, completed }),

--- a/src/components/EnrollButton/index.tsx
+++ b/src/components/EnrollButton/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
 import { cn } from '@/utilities/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type EnrollState = 'not-logged-in' | 'no-access' | 'can-enroll' | 'enrolled' | 'completed'
 
@@ -18,7 +19,7 @@ export const EnrollButton: React.FC<{
   const handleEnroll = async () => {
     setLoading(true)
     try {
-      const res = await fetch('/api/enroll', {
+      const res = await fetch(apiUrl('/api/enroll'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ courseId }),

--- a/src/components/LessonNav/index.tsx
+++ b/src/components/LessonNav/index.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import Link from 'next/link'
 import { cn } from '@/utilities/ui'
 import { useAuth } from '@/providers/Auth'
+import { apiUrl } from '@/utilities/apiUrl'
 
 export const LessonNav: React.FC<{
   prevHref?: string | null
@@ -21,14 +22,14 @@ export const LessonNav: React.FC<{
     try {
       if (lessonProgressId) {
         // Update existing progress
-        await fetch(`/api/lesson-progress/${lessonProgressId}`, {
+        await fetch(apiUrl(`/api/lesson-progress/${lessonProgressId}`), {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ status: 'completed' }),
         })
       } else {
         // Create new progress record
-        await fetch('/api/lesson-progress', {
+        await fetch(apiUrl('/api/lesson-progress'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/src/components/OnboardingTour/index.tsx
+++ b/src/components/OnboardingTour/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { cn } from '@/utilities/ui'
 import { X } from 'lucide-react'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type TourStep = {
   title: string
@@ -79,7 +80,7 @@ export const OnboardingTour: React.FC<{ userId: string }> = ({ userId }) => {
   const complete = async () => {
     setDismissed(true)
     try {
-      await fetch(`/api/users/${userId}`, {
+      await fetch(apiUrl(`/api/users/${userId}`), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ hasCompletedOnboarding: true }),

--- a/src/components/RelatedContentPanel/index.tsx
+++ b/src/components/RelatedContentPanel/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState } from 'react'
 import { useDocumentInfo } from '@payloadcms/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type RelatedItem = {
   id: string
@@ -22,7 +23,7 @@ export const RelatedContentPanel: React.FC = () => {
 
     try {
       // Fetch current document content
-      const docRes = await fetch(`/api/${collectionSlug}/${id}?depth=0`)
+      const docRes = await fetch(apiUrl(`/api/${collectionSlug}/${id}?depth=0`))
       const doc = await docRes.json()
 
       // Extract text from content field
@@ -34,7 +35,7 @@ export const RelatedContentPanel: React.FC = () => {
       }
 
       // Call related content endpoint
-      const res = await fetch('/api/ai/related-content', {
+      const res = await fetch(apiUrl('/api/ai/related-content'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/TutorPanel/index.tsx
+++ b/src/components/TutorPanel/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { X, Send, MessageCircle, Copy, Activity } from 'lucide-react'
 import { cn } from '@/utilities/ui'
+import { apiUrl } from '@/utilities/apiUrl'
 
 const SUGGESTED_QUESTIONS: Record<string, string[]> = {
   articles: [
@@ -103,7 +104,7 @@ export const TutorPanel: React.FC<{
     setLoading(true)
 
     try {
-      const res = await fetch('/api/ai/tutor', {
+      const res = await fetch(apiUrl('/api/ai/tutor'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/providers/Auth/index.tsx
+++ b/src/providers/Auth/index.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useEffect, useState } fr
 import { useRouter } from 'next/navigation'
 
 import type { User } from '@/payload-types'
+import { apiUrl } from '@/utilities/apiUrl'
 
 type AuthStatus = 'loading' | 'loggedIn' | 'loggedOut'
 
@@ -27,7 +28,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const fetchMe = useCallback(async () => {
     try {
-      const res = await fetch('/api/users/me', { credentials: 'include' })
+      const res = await fetch(apiUrl('/api/users/me'), { credentials: 'include' })
       if (res.ok) {
         const data = await res.json()
         if (data?.user) {
@@ -55,7 +56,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = useCallback(async () => {
     try {
-      await fetch('/api/users/logout', { method: 'POST', credentials: 'include' })
+      await fetch(apiUrl('/api/users/logout'), { method: 'POST', credentials: 'include' })
     } catch {
       // Proceed with client-side cleanup even if request fails
     }

--- a/src/utilities/apiUrl.ts
+++ b/src/utilities/apiUrl.ts
@@ -1,0 +1,4 @@
+export function apiUrl(path: string): string {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+  return `${basePath}${path}`
+}


### PR DESCRIPTION
## Summary
- Add `src/utilities/apiUrl.ts` — prepends `NEXT_PUBLIC_BASE_PATH` (e.g. `/learn`) to API paths
- Update all 26 `fetch('/api/...')` calls across 16 client components to use `apiUrl()`
- **Root cause**: Next.js `basePath` only applies to `<Link>` and `router.push()`, not raw `fetch()`. All API calls through the gateway were hitting `/api/*` instead of `/learn/api/*`, breaking login and every other API interaction.

### Files updated
Auth provider, LoginForm, RegisterForm, ForgotPasswordForm, ResetPasswordForm, VerifyEmailForm, ProfilePage, SearchClient, DiscoverClient, TutorPanel, EnrollButton, LessonNav, OnboardingTour, RelatedContentPanel, ActionPlanCTA, DailyProtocolWidget

## Test plan
- [x] `pnpm build` passes
- [x] `grep` confirms zero remaining `fetch('/api/` calls
- [ ] Verify login works at `paths-api.limitless-longevity.health/learn/login`
- [ ] Verify auth persists to `app.limitless-longevity.health` OS Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)