### PR TITLE
Switch health data reads to Digital Twin API (Phase 3B)

### DIFF
--- a/src/app/(frontend)/account/health/page.tsx
+++ b/src/app/(frontend)/account/health/page.tsx
@@ -6,6 +6,53 @@ import HealthProfileClient from './HealthProfileClient'
 
 export const dynamic = 'force-dynamic'
 
+/**
+ * Fetch health profile from Digital Twin API, with Payload fallback.
+ */
+async function fetchHealthFromDT(userId: string): Promise<any | null> {
+  const dtUrl = process.env.DT_SERVICE_URL
+  const dtKey = process.env.DT_SERVICE_KEY
+
+  if (!dtUrl || !dtKey) return null
+
+  try {
+    const headers = { 'x-service-key': dtKey }
+
+    const [profileRes, biomarkersRes] = await Promise.all([
+      fetch(`${dtUrl}/api/twin/${userId}/profile`, { headers }),
+      fetch(`${dtUrl}/api/twin/${userId}/biomarkers?limit=50`, { headers }),
+    ])
+
+    if (!profileRes.ok) return null
+
+    const profile = await profileRes.json()
+    const bioData = biomarkersRes.ok ? await biomarkersRes.json() : null
+    const biomarkers = bioData?.biomarkers ?? []
+
+    return {
+      user: userId,
+      conditions: (profile.conditions ?? []).map((c: string) => ({ condition: c })),
+      medications: (profile.medications ?? []).map((m: string) => ({ medication: m })),
+      healthGoals: (profile.healthGoals ?? []).map((g: string) => ({ goal: g })),
+      pillarPriorities: Object.entries(profile.pillarPriorities ?? {} as Record<string, number>)
+        .sort(([, a], [, b]) => (a as number) - (b as number))
+        .map(([key]) => ({ pillar: { name: key } })),
+      biomarkers: biomarkers.map((b: any) => ({
+        name: b.name,
+        value: b.value,
+        unit: b.unit,
+        date: b.measuredAt,
+        normalRangeLow: b.referenceMin ?? undefined,
+        normalRangeHigh: b.referenceMax ?? undefined,
+        status: b.status,
+      })),
+    }
+  } catch (err) {
+    console.warn('[health/page] DT unreachable, falling back to Payload:', (err as Error).message)
+    return null
+  }
+}
+
 export default async function HealthProfilePage() {
   const payload = await getPayload({ config: configPromise })
   const headersList = await getHeaders()
@@ -13,16 +60,23 @@ export default async function HealthProfilePage() {
 
   if (!user) return null
 
-  // Fetch existing health profile
-  const profileResult = await payload.find({
-    collection: 'health-profiles',
-    where: { user: { equals: user.id } },
-    limit: 1,
-    depth: 1,
-    overrideAccess: true,
-  })
+  const userId = user.id as string
 
-  // Fetch content pillars for priorities
+  // Try DT first, fall back to Payload
+  let existingProfile = await fetchHealthFromDT(userId)
+
+  if (!existingProfile) {
+    const profileResult = await payload.find({
+      collection: 'health-profiles',
+      where: { user: { equals: userId } },
+      limit: 1,
+      depth: 1,
+      overrideAccess: true,
+    })
+    existingProfile = profileResult.docs[0] || null
+  }
+
+  // Fetch content pillars for priorities (always from Payload — these are PATHS content)
   const pillarsResult = await payload.find({
     collection: 'content-pillars',
     where: { isActive: { equals: true } },
@@ -30,7 +84,6 @@ export default async function HealthProfilePage() {
     limit: 20,
   })
 
-  const existingProfile = profileResult.docs[0] || null
   const pillars = pillarsResult.docs.map((p: any) => ({
     id: p.id,
     name: p.name,
@@ -40,7 +93,7 @@ export default async function HealthProfilePage() {
     <HealthProfileClient
       existingProfile={existingProfile}
       pillars={pillars}
-      userId={user.id as string}
+      userId={userId}
     />
   )
 }

--- a/src/utilities/getHealthProfile.ts
+++ b/src/utilities/getHealthProfile.ts
@@ -1,7 +1,8 @@
 import type { Payload, PayloadRequest } from 'payload'
 
 /**
- * Fetch a user's health profile. Returns null if no profile exists.
+ * Fetch a user's health profile from the Digital Twin API.
+ * Falls back to local Payload query if DT is unreachable.
  * Used by AI endpoints for personalization with graceful degradation.
  */
 export async function getHealthProfile(
@@ -9,6 +10,33 @@ export async function getHealthProfile(
   payload: Payload,
   req: PayloadRequest,
 ): Promise<any | null> {
+  const dtUrl = process.env.DT_SERVICE_URL
+  const dtKey = process.env.DT_SERVICE_KEY
+
+  if (dtUrl && dtKey) {
+    try {
+      const headers = { 'x-service-key': dtKey }
+
+      const [profileRes, biomarkersRes] = await Promise.all([
+        fetch(`${dtUrl}/api/twin/${userId}/profile`, { headers }),
+        fetch(`${dtUrl}/api/twin/${userId}/biomarkers?limit=50`, { headers }),
+      ])
+
+      if (profileRes.ok) {
+        const profile = await profileRes.json()
+        const bioData = biomarkersRes.ok ? await biomarkersRes.json() : null
+
+        return transformDTResponse(profile, bioData?.biomarkers ?? [])
+      }
+
+      // DT returned non-OK — fall through to Payload
+      console.warn(`[getHealthProfile] DT profile fetch returned ${profileRes.status} for user ${userId}, falling back to Payload`)
+    } catch (err) {
+      console.warn(`[getHealthProfile] DT unreachable for user ${userId}, falling back to Payload:`, (err as Error).message)
+    }
+  }
+
+  // Fallback: local Payload query
   try {
     const result = await payload.find({
       collection: 'health-profiles',
@@ -21,5 +49,45 @@ export async function getHealthProfile(
     return result.docs[0] ?? null
   } catch {
     return null
+  }
+}
+
+/**
+ * Transform DT API response to match the Payload HealthProfile shape
+ * that AI endpoints and the health page expect.
+ */
+function transformDTResponse(
+  profile: {
+    conditions?: string[]
+    medications?: string[]
+    healthGoals?: string[]
+    pillarPriorities?: Record<string, number>
+  },
+  biomarkers: {
+    name: string
+    value: number
+    unit: string
+    measuredAt: string
+    referenceMin?: number | null
+    referenceMax?: number | null
+    status: string
+  }[],
+): any {
+  return {
+    conditions: (profile.conditions ?? []).map((c) => ({ condition: c })),
+    medications: (profile.medications ?? []).map((m) => ({ medication: m })),
+    healthGoals: (profile.healthGoals ?? []).map((g) => ({ goal: g })),
+    pillarPriorities: Object.entries(profile.pillarPriorities ?? {})
+      .sort(([, a], [, b]) => a - b)
+      .map(([key]) => ({ pillar: { name: key } })),
+    biomarkers: biomarkers.map((b) => ({
+      name: b.name,
+      value: b.value,
+      unit: b.unit,
+      date: b.measuredAt,
+      normalRangeLow: b.referenceMin ?? undefined,
+      normalRangeHigh: b.referenceMax ?? undefined,
+      status: b.status,
+    })),
   }
 }


### PR DESCRIPTION
## Summary
- **`src/utilities/getHealthProfile.ts`** — Now fetches from DT API first (`GET /api/twin/{userId}/profile` + `/biomarkers?limit=50`), transforms response to match Payload HealthProfile shape, falls back to local Payload query if DT is unreachable or returns non-OK. Used by all AI endpoints (tutor, action plan, daily protocol).
- **`src/app/(frontend)/account/health/page.tsx`** — Server component reads from DT with service key auth, falls back to Payload. Content pillars always from Payload. Write path unchanged.

**Field mapping (DT → Payload shape):**
- `conditions[]` strings → `{ condition: string }[]`
- `medications[]` strings → `{ medication: string }[]`
- `healthGoals[]` strings → `{ goal: string }[]`
- `pillarPriorities{}` map → sorted `{ pillar: { name } }[]`
- `referenceMin` → `normalRangeLow`, `referenceMax` → `normalRangeHigh`, `measuredAt` → `date`

**Not modified:** AI endpoints, prompt builders, HealthProfileClient, HealthProfiles collection.

## Test plan
- [x] `pnpm build` passes
- [ ] Health page loads profile from DT when available
- [ ] AI tutor/action plan/daily protocol use DT data
- [ ] Fallback to Payload works when DT_SERVICE_URL is unset
- [ ] Fallback works when DT is unreachable (timeout/error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)